### PR TITLE
Pin numpy dependency for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 craft-text-detector>=0.4.5
 Pillow>=9.0.0
+numpy<2


### PR DESCRIPTION
## Summary
- add an explicit numpy<2 requirement to avoid runtime incompatibilities with opencv-based dependencies

## Testing
- pip install -r requirements.txt *(fails: proxy prevents downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68de609357fc8322bc399773f50f5350