### PR TITLE
Change bounding box color to green

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,7 +192,7 @@ def draw_bounding_boxes(image: Image.Image, boxes: Sequence[BoundingBox]) -> Ima
     draw = ImageDraw.Draw(annotated)
 
     for box in boxes:
-        draw.rectangle(box.to_tuple(), outline="red", width=2)
+        draw.rectangle(box.to_tuple(), outline="green", width=2)
 
     return annotated
 


### PR DESCRIPTION
## Summary
- change the bounding box drawing outline color to green for detected text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9dfaf7ec832293060516e8523431